### PR TITLE
Added shortcut for opening chrome dev tools

### DIFF
--- a/src/Positron.UI/Builder/PositronUiBuilder.cs
+++ b/src/Positron.UI/Builder/PositronUiBuilder.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Positron.Server;
-using System.Configuration;
 using Positron.UI.Internal;
 
 namespace Positron.UI.Builder
@@ -69,9 +68,9 @@ namespace Positron.UI.Builder
                 throw new InvalidOperationException("An IWebHost must be provided via SetWebHost.");
             }
 
-            var services = BuildServices();
-            var serviceProvider = services.BuildServiceProvider();
             var settings = new CefSettings();
+            var services = BuildServices(settings);
+            var serviceProvider = services.BuildServiceProvider();
 
             foreach (var options in serviceProvider.GetServices<IConfigureOptions<CefSettings>>())
             {
@@ -94,7 +93,7 @@ namespace Positron.UI.Builder
             });
         }
 
-        private IServiceCollection BuildServices()
+        private IServiceCollection BuildServices(CefSettings settings)
         {
             var services = new ServiceCollection();
 
@@ -105,7 +104,7 @@ namespace Positron.UI.Builder
             services.TryAddSingleton<IRequestHandler, RequestHandler>();
             services.TryAddSingleton<IWindowHandler, WindowHandler>();
             services.TryAddSingleton<ILifeSpanHandler, LifeSpanHandler>();
-            services.TryAddSingleton<IKeyboardHandler, KeyboardHandler>();
+            services.TryAddSingleton<IKeyboardHandler>(new KeyboardHandler(settings));
 
             services.TryAddSingleton(_webHost.Services.GetService<IAppSchemeResourceResolver>());
             services.AddSingleton(_webHost);

--- a/src/Positron.UI/KeyboardHandler.cs
+++ b/src/Positron.UI/KeyboardHandler.cs
@@ -1,27 +1,34 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using CefSharp;
+﻿using CefSharp;
 using System.Diagnostics;
-using System.Windows.Forms;
-using System.Windows.Controls;
-using System.Windows.Input;
+
 
 namespace Positron.UI
 {
     public class KeyboardHandler : IKeyboardHandler
     {
         private const int ControlRCode = 18;
+        private const int F12Code = 123;
+
+        private CefSettings Settings { get; }
+
+        public KeyboardHandler(CefSettings settings)
+        {
+            Settings = settings;
+        }
 
         public bool OnKeyEvent(IWebBrowser browserControl, IBrowser browser, KeyType type, int windowsKeyCode, int nativeKeyCode, CefEventFlags modifiers, bool isSystemKey)
         {
             var isHandled = false;
 
+
             switch (type)
             {
                 case KeyType.RawKeyDown:
+                    if (windowsKeyCode == F12Code && Settings.RemoteDebuggingPort != default(int))
+                    {
+                        Process.Start("chrome.exe", "http://localhost:" + Settings.RemoteDebuggingPort);
+                        isHandled = true;
+                    }
                     break;
                 case KeyType.KeyUp:
                     break;
@@ -31,7 +38,6 @@ namespace Positron.UI
                         browserControl.Reload();
                         isHandled = true;
                     }
-
                     break;
             }
 
@@ -45,6 +51,10 @@ namespace Positron.UI
             switch (type)
             {
                 case KeyType.RawKeyDown:
+                    if (windowsKeyCode == F12Code)
+                    {
+                        isKeyboardShortcut = true;
+                    }
                     break;
                 case KeyType.KeyUp:
                     break;
@@ -53,22 +63,10 @@ namespace Positron.UI
                     {
                         isKeyboardShortcut = true;
                     }
-
                     break;
             }
 
             return isHandled;
-        }
-
-        private void HandleChar()
-        {
-
-        }
-
-
-        private void RefreshPage()
-        {
-
         }
     }
 }

--- a/src/Positron.UI/Positron.UI.csproj
+++ b/src/Positron.UI/Positron.UI.csproj
@@ -39,7 +39,6 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />


### PR DESCRIPTION
Motivation
----------
As a developer I want an easy way to open the dev tools using the appropriate port

Modifications
-------------

Added code to KeyboardHandler to support new devTools shortcut.

Results
-------

The ability to start chrome dev tools by hitting F12