### PR TITLE
Allow customization of resource filtering for security

### DIFF
--- a/src/Positron.UI/Builder/PositronUiBuilder.cs
+++ b/src/Positron.UI/Builder/PositronUiBuilder.cs
@@ -137,6 +137,7 @@ namespace Positron.UI.Builder
             //This is required to add ILogger of T.
             services.AddLogging();
 
+            services.TryAddSingleton<IResourceRequestFilter, PositronOnlyResourceRequestFilter>();
             services.TryAddSingleton<IBrowserProcessHandler, BrowserProcessHandler>();
             services.TryAddSingleton<IRequestHandler, RequestHandler>();
             services.TryAddSingleton<IResourceHandlerFactory, PositronResourceHandlerFactory>();

--- a/src/Positron.UI/HostResourceRequestFilter.cs
+++ b/src/Positron.UI/HostResourceRequestFilter.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Positron.UI
+{
+    /// <summary>
+    /// Base class for a resource request filter that filters based on scheme and host.
+    /// </summary>
+    public abstract class HostResourceRequestFilter : IResourceRequestFilter
+    {
+        /// <summary>
+        /// List of valid schemes, i.e. "http" and "https".
+        /// </summary>
+        public abstract HashSet<string> ValidSchemes { get; }
+
+        /// <summary>
+        /// List of valid hosts, i.e. "positron" or "google.com".
+        /// </summary>
+        public abstract HashSet<string> ValidHosts { get; }
+
+        /// <inheritdoc cref="IResourceRequestFilter"/>
+        public virtual Task<bool> CanLoadResourceAsync(ResourceRequestContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            if (context.Url == null)
+            {
+                throw new ArgumentException("ResourceRequestContext.Url may not be null.", nameof(context));
+            }
+            if (!context.Url.IsAbsoluteUri)
+            {
+                throw new ArgumentException("ResourceRequestContext.Url must be absolute.", nameof(context));
+            }
+
+            var result = ValidSchemes.Contains(context.Url.Scheme) && ValidHosts.Contains(context.Url.Host);
+
+            if (!result)
+            {
+                OnResourceRejection(context);
+            }
+
+            return Task.FromResult(result);
+        }
+
+        /// <summary>
+        /// Called when a resource is rejected to permit logging.
+        /// </summary>
+        /// <param name="context"><see cref="ResourceRequestContext"/> of the resource being rejected.</param>
+        public virtual void OnResourceRejection(ResourceRequestContext context)
+        {
+        }
+    }
+}

--- a/src/Positron.UI/IResourceRequestFilter.cs
+++ b/src/Positron.UI/IResourceRequestFilter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Positron.UI
+{
+    /// <summary>
+    /// Filter requests for resource load to provide application security
+    /// </summary>
+    public interface IResourceRequestFilter
+    {
+        /// <summary>
+        /// Evaluates a request and returns true if the resource may be safely loaded in Chromium.
+        /// </summary>
+        /// <param name="context"><see cref="ResourceRequestContext"/> to evaluate.</param>
+        /// <returns>True if the resource may be safely loaded in Chromium.</returns>
+        Task<bool> CanLoadResourceAsync(ResourceRequestContext context);
+    }
+}

--- a/src/Positron.UI/Internal/LoggerEventIds.cs
+++ b/src/Positron.UI/Internal/LoggerEventIds.cs
@@ -28,5 +28,6 @@
 
         // ResourceHandler
         public const int ExternalResource = 500;
+        public const int ResourceRequestFilterError = 501;
     }
 }

--- a/src/Positron.UI/Internal/PositronOnlyResourceRequestFilter.cs
+++ b/src/Positron.UI/Internal/PositronOnlyResourceRequestFilter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CefSharp;
+using Microsoft.Extensions.Logging;
+
+namespace Positron.UI.Internal
+{
+    internal class PositronOnlyResourceRequestFilter : HostResourceRequestFilter
+    {
+        private readonly ILogger<PositronOnlyResourceRequestFilter> _logger;
+
+        public override HashSet<string> ValidSchemes { get; } = new HashSet<string> {"http"};
+        public override HashSet<string> ValidHosts { get; } = new HashSet<string> {"positron"};
+
+        public PositronOnlyResourceRequestFilter(ILogger<PositronOnlyResourceRequestFilter> logger)
+        {
+            _logger = logger;
+        }
+
+        public override void OnResourceRejection(ResourceRequestContext context)
+        {
+            _logger.LogWarning(LoggerEventIds.ExternalResource, "Preventing load of external resource '{0}'", context.Url);
+        }
+    }
+}

--- a/src/Positron.UI/Positron.UI.csproj
+++ b/src/Positron.UI/Positron.UI.csproj
@@ -52,7 +52,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Builder\PositronUiBuilderExtensions.cs" />
+    <Compile Include="HostResourceRequestFilter.cs" />
     <Compile Include="Internal\LoggerEventIds.cs" />
+    <Compile Include="Internal\PositronOnlyResourceRequestFilter.cs" />
     <Compile Include="Internal\PositronResourceHandlerFactory.cs" />
     <Compile Include="Internal\PositronResourceHandler.cs" />
     <Compile Include="Internal\BrowserProcessHandler.cs" />
@@ -62,6 +64,7 @@
     <Compile Include="IConsoleLogger.cs" />
     <Compile Include="Internal\NullConsoleLogger.cs" />
     <Compile Include="Internal\KeyboardHandler.cs" />
+    <Compile Include="IResourceRequestFilter.cs" />
     <Compile Include="PositronWindow.xaml.cs">
       <DependentUpon>PositronWindow.xaml</DependentUpon>
     </Compile>
@@ -72,6 +75,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Internal\RequestHandler.cs" />
     <Compile Include="Internal\PositronUi.cs" />
+    <Compile Include="ResourceRequestContext.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/Positron.UI/ResourceRequestContext.cs
+++ b/src/Positron.UI/ResourceRequestContext.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Positron.UI
+{
+    /// <summary>
+    /// Information about a Chromium request before it is processed.
+    /// </summary>
+    public class ResourceRequestContext
+    {
+        /// <summary>
+        /// Request method, i.e. "GET" or "POST".
+        /// </summary>
+        public string Method { get; set; }
+
+        /// <summary>
+        /// <see cref="Uri"/> of the referrer, if any.
+        /// </summary>
+        public Uri Referrer { get; set; }
+
+        /// <summary>
+        /// <see cref="Uri"/> being requested.  Should be an absolute Uri.
+        /// </summary>
+        public Uri Url { get; set; }
+    }
+}

--- a/test/Positron.Application/Views/Home/Index.cshtml
+++ b/test/Positron.Application/Views/Home/Index.cshtml
@@ -5,5 +5,6 @@
     <a href="javascript: console.log('Test Log');">Console Logging Test</a><br />
     <a href="#" id="TestAjax">Ajax Request</a><br />
     <a href="#" id="TestId">ID Route With Space Test</a><br />
-    @Html.ActionLink("Form Test", "FormTest")
+    @Html.ActionLink("Form Test", "FormTest")<br />
+    <a href="http://google.com/">Unsafe Url</a><br />
 </p>


### PR DESCRIPTION
Motivation
----------
Current security paradigm blocks all traffic out of Chromium except for
traffic to the internal Positron server.  This is great for security,
but limiting.

Modifications
-------------
Implement IResourceRequestFilter abstraction layer on top of the
OnBeforeResourceLoad method of RequestHandler.

Add a base class, HostResourceRequestFilter, which can be used to
easily implement simple filtering.

Implement the current functionality in
PositronOnlyResourceRequestFilter, which is the registered filter by
default.

Add a test link to the test application.

Results
-------
Current behavior is unchanged, but users may now relax the filtering
restrictions as desired.  API is asynchronous in case external sources
need to be consulted before allowing traffic.