### PR TITLE
Issue #8: Support for customizing window.alert() user interface

### DIFF
--- a/src/Positron.UI/Builder/IPositronUiBuilder.cs
+++ b/src/Positron.UI/Builder/IPositronUiBuilder.cs
@@ -44,6 +44,7 @@ namespace Positron.UI.Builder
         /// <returns>The <see cref="IPositronUiBuilder"/>.</returns>
         IPositronUiBuilder SetWebHost(IWebHost webHost);
 
+        /// <summary>
         /// Specify the <see cref="ILoggerFactory"/> to be used by the web host.
         /// </summary>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to be used.</param>

--- a/src/Positron.UI/Builder/PositronUiBuilder.cs
+++ b/src/Positron.UI/Builder/PositronUiBuilder.cs
@@ -143,6 +143,7 @@ namespace Positron.UI.Builder
             services.TryAddSingleton<IResourceHandlerFactory, PositronResourceHandlerFactory>();
             services.TryAddSingleton<IPositronUi, PositronUi>();
             services.TryAddSingleton<ILifeSpanHandler, LifeSpanHandler>();
+            services.TryAddSingleton<IJsDialogHandler, PositronJsDialogHandler>();
             services.TryAddSingleton<IKeyboardHandler, KeyboardHandler>();
 
             services.TryAddSingleton(_webHost.Services.GetService<IPositronResourceResolver>());

--- a/src/Positron.UI/Dialog/DialogContext.cs
+++ b/src/Positron.UI/Dialog/DialogContext.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CefSharp;
+
+namespace Positron.UI.Dialog
+{
+    /// <summary>
+    /// Information about a Javascript request for dialog, such as window.alert().
+    /// </summary>
+    public class DialogContext
+    {
+        /// <summary>
+        /// Text of the message to display.
+        /// </summary>
+        public string MessageText { get; set; }
+
+        /// <summary>
+        /// Origin URL which requested the dialog.
+        /// </summary>
+        public Uri OriginUrl { get; set; }
+
+        /// <summary>
+        /// <see cref="PositronWindow"/> which requested the dialog.
+        /// </summary>
+        public PositronWindow Window { get; set; }
+
+        /// <summary>
+        /// If set to true during a call to WillHandleXXX in <see cref="IPositronDialogHandler"/>,
+        /// and if WillHandleXXX returns false, it will also suppress the default dialog.
+        /// </summary>
+        public bool SuppressDefaultDialog { get; set; } = false;
+    }
+}

--- a/src/Positron.UI/Dialog/IPositronDialogHandler.cs
+++ b/src/Positron.UI/Dialog/IPositronDialogHandler.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Positron.UI.Dialog
+{
+    /// <summary>
+    /// Handler for Javascript dialog events such as window.alert(), window.confirm(), and window.prompt().
+    /// Allows customization of application behavior for these dialogs.
+    /// </summary>
+    public interface IPositronDialogHandler
+    {
+        /// <summary>
+        /// Returns true if the handler will handle the alert request.
+        /// </summary>
+        /// <param name="context">Information about the requested alert.</param>
+        /// <returns>True if the handler will handle the alert request, suppressing the default behavior.</returns>
+        /// <remarks>May also see <see cref="DialogContext.SuppressDefaultDialog"/> to prevent any UI from appearing.</remarks>
+        bool WillHandleAlert(DialogContext context);
+
+        /// <summary>
+        /// Returns true if the handler will handle the confirmation request.
+        /// </summary>
+        /// <param name="context">Information about the requested confirmation.</param>
+        /// <returns>True if the handler will handle the confirmation request, suppressing the default behavior.</returns>
+        /// <remarks>May also see <see cref="DialogContext.SuppressDefaultDialog"/> to prevent any UI from appearing.</remarks>
+        bool WillHandleConfirmation(DialogContext context);
+
+        /// <summary>
+        /// Returns true if the handler will handle the prompt request.
+        /// </summary>
+        /// <param name="context">Information about the requested prompt.</param>
+        /// <returns>True if the handler will handle the prompt request, suppressing the default behavior.</returns>
+        /// <remarks>May also see <see cref="DialogContext.SuppressDefaultDialog"/> to prevent any UI from appearing.</remarks>
+        bool WillHandlePrompt(PromptDialogContext context);
+
+        /// <summary>
+        /// Displays an alert to the user.
+        /// </summary>
+        /// <param name="context">Information about the requested alert.</param>
+        /// <returns>Task which completes after OK is pressed by the user.</returns>
+        Task HandleAlert(DialogContext context);
+
+        /// <summary>
+        /// Displays a prompt for user confirmation.
+        /// </summary>
+        /// <param name="context">Information about the requested confirmation.</param>
+        /// <returns>Task with true for yes or false for no.</returns>
+        Task<bool> HandleConfirmation(DialogContext context);
+
+        /// <summary>
+        /// Displays a prompt for user input.  Input should be stored in <see cref="PromptDialogContext.PromptText"/>.
+        /// </summary>
+        /// <param name="context">Information about the requested prompt.</param>
+        /// <returns>Task with true for success or false for user cancellation.</returns>
+        Task<bool> HandlePrompt(PromptDialogContext context);
+    }
+}

--- a/src/Positron.UI/Dialog/PromptDialogContext.cs
+++ b/src/Positron.UI/Dialog/PromptDialogContext.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Positron.UI.Dialog
+{
+    /// <summary>
+    /// Extension  of <see cref="DialogContext"/> specific to prompts for user input (window.prompt).
+    /// </summary>
+    public class PromptDialogContext : DialogContext
+    {
+        /// <summary>
+        /// Before the prompt, has the initial value for the prompt.
+        /// It should be filled with the string entered by the user when complete.
+        /// </summary>
+        public string PromptText { get; set; }
+    }
+}

--- a/src/Positron.UI/Internal/LoggerEventIds.cs
+++ b/src/Positron.UI/Internal/LoggerEventIds.cs
@@ -29,5 +29,9 @@
         // ResourceHandler
         public const int ExternalResource = 500;
         public const int ResourceRequestFilterError = 501;
+
+        // DialogHandler
+        public const int DialogHandlerError = 600;
+        public const int UnknownDialogType = 601;
     }
 }

--- a/src/Positron.UI/Internal/PositronJsDialogHandler.cs
+++ b/src/Positron.UI/Internal/PositronJsDialogHandler.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CefSharp;
+using CefSharp.Wpf;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Positron.UI.Dialog;
+
+namespace Positron.UI.Internal
+{
+    internal class PositronJsDialogHandler : IJsDialogHandler
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<PositronJsDialogHandler> _logger;
+
+        public PositronJsDialogHandler(IServiceProvider serviceProvider, ILogger<PositronJsDialogHandler> logger)
+        {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        public bool OnJSDialog(IWebBrowser browserControl, IBrowser browser, string originUrl, CefJsDialogType dialogType,
+            string messageText, string defaultPromptText, IJsDialogCallback callback, ref bool suppressMessage)
+        {
+            try
+            {
+                var wpfBrowser = browserControl as ChromiumWebBrowser;
+                var window = wpfBrowser?.Parent as PositronWindow;
+                if (window == null)
+                {
+                    // Ignore if not within a Positron window
+                    callback.Dispose();
+                    suppressMessage = false;
+                    return false;
+                }
+
+                DialogContext context = dialogType == CefJsDialogType.Prompt
+                    ? new PromptDialogContext
+                    {
+                        PromptText = defaultPromptText
+                    }
+                    : new DialogContext();
+
+                context.Window = window;
+                context.OriginUrl = new Uri(originUrl);
+                context.MessageText = messageText;
+
+                var dialogHandler = _serviceProvider.GetService<IPositronDialogHandler>();
+                if (dialogHandler == null)
+                {
+                    // Use default behavior
+                    callback.Dispose();
+                    suppressMessage = false;
+                    return false;
+                }
+
+                bool handled;
+                switch (dialogType)
+                {
+                    case CefJsDialogType.Alert:
+                        handled = HandleAlert(dialogHandler, context, callback);
+                        break;
+
+                    case CefJsDialogType.Confirm:
+                        handled = HandleConfirmation(dialogHandler, context, callback);
+                        break;
+
+                    case CefJsDialogType.Prompt:
+                        handled = HandlePrompt(dialogHandler, (PromptDialogContext) context, callback);
+                        break;
+
+                    default:
+                        handled = false;
+                        _logger.LogWarning(LoggerEventIds.UnknownDialogType, "Unknown dialog type: {0}", dialogType);
+                        break;
+                }
+
+                suppressMessage = !handled && context.SuppressDefaultDialog;
+                return handled;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(LoggerEventIds.DialogHandlerError, ex, "Error in IPositronDialogHandler");
+
+                callback.Dispose();
+                suppressMessage = false;
+                return false;
+            }
+        }
+
+        public bool OnJSBeforeUnload(IWebBrowser browserControl, IBrowser browser, string message, bool isReload,
+            IJsDialogCallback callback)
+        {
+            // Use default behavior
+            return false;
+        }
+
+        public void OnResetDialogState(IWebBrowser browserControl, IBrowser browser)
+        {
+        }
+
+        public void OnDialogClosed(IWebBrowser browserControl, IBrowser browser)
+        {
+        }
+
+        private bool HandleAlert(IPositronDialogHandler handler, DialogContext context, IJsDialogCallback callback)
+        {
+            if (!handler.WillHandleAlert(context))
+            {
+                return false;
+            }
+
+            var task = handler.HandleAlert(context)
+                .ContinueWith(task2 =>
+                {
+                    using (callback)
+                    {
+                        callback.Continue(true);
+                    }
+                }, TaskContinuationOptions.OnlyOnRanToCompletion);
+
+            HandleErrors(task, callback);
+
+            return true;
+        }
+
+        private bool HandleConfirmation(IPositronDialogHandler handler, DialogContext context, IJsDialogCallback callback)
+        {
+            if (!handler.WillHandleConfirmation(context))
+            {
+                return false;
+            }
+
+            var task = handler.HandleConfirmation(context)
+                .ContinueWith(task2 =>
+                {
+                    using (callback)
+                    {
+                        callback.Continue(task2.Result);
+                    }
+                }, TaskContinuationOptions.OnlyOnRanToCompletion);
+
+            HandleErrors(task, callback);
+
+            return true;
+        }
+
+        private bool HandlePrompt(IPositronDialogHandler handler, PromptDialogContext context, IJsDialogCallback callback)
+        {
+            if (!handler.WillHandlePrompt(context))
+            {
+                return false;
+            }
+
+            var task = handler.HandlePrompt(context)
+                .ContinueWith(task2 =>
+                {
+                    using (callback)
+                    {
+                        callback.Continue(task2.Result, context.PromptText);
+                    }
+                }, TaskContinuationOptions.OnlyOnRanToCompletion);
+
+            HandleErrors(task, callback);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Adds generic ContinueWith for errors and cancellations.
+        /// </summary>
+        private void HandleErrors(Task task, IJsDialogCallback callback)
+        {
+            task.ContinueWith(task2 =>
+            {
+                using (callback)
+                {
+                    if (task2.IsFaulted)
+                    {
+                        _logger.LogError(LoggerEventIds.DialogHandlerError, task2.Exception,
+                            "Error in IPositronDialogHandler");
+
+                        callback.Continue(false);
+                    }
+                    else
+                    {
+                        _logger.LogError(LoggerEventIds.DialogHandlerError, "Cancellation in IPositronDialogHandler");
+
+                        callback.Continue(false);
+                    }
+                }
+            }, TaskContinuationOptions.NotOnRanToCompletion);
+        }
+    }
+}

--- a/src/Positron.UI/Internal/PositronUi.cs
+++ b/src/Positron.UI/Internal/PositronUi.cs
@@ -42,7 +42,8 @@ namespace Positron.UI.Internal
                 RequestHandler = Services.GetRequiredService<IRequestHandler>(),
                 LifeSpanHandler = Services.GetRequiredService<ILifeSpanHandler>(),
                 KeyboardHandler = Services.GetRequiredService<IKeyboardHandler>(),
-                ResourceHandlerFactory = Services.GetRequiredService<IResourceHandlerFactory>()
+                ResourceHandlerFactory = Services.GetRequiredService<IResourceHandlerFactory>(),
+                JsDialogHandler = Services.GetRequiredService<IJsDialogHandler>()
             };
 
             if (!_globalScriptObjectsRegistered)

--- a/src/Positron.UI/Positron.UI.csproj
+++ b/src/Positron.UI/Positron.UI.csproj
@@ -52,8 +52,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Builder\PositronUiBuilderExtensions.cs" />
+    <Compile Include="Dialog\DialogContext.cs" />
+    <Compile Include="Dialog\PromptDialogContext.cs" />
     <Compile Include="HostResourceRequestFilter.cs" />
     <Compile Include="Internal\LoggerEventIds.cs" />
+    <Compile Include="Internal\PositronJsDialogHandler.cs" />
     <Compile Include="Internal\PositronOnlyResourceRequestFilter.cs" />
     <Compile Include="Internal\PositronResourceHandlerFactory.cs" />
     <Compile Include="Internal\PositronResourceHandler.cs" />
@@ -64,6 +67,7 @@
     <Compile Include="IConsoleLogger.cs" />
     <Compile Include="Internal\NullConsoleLogger.cs" />
     <Compile Include="Internal\KeyboardHandler.cs" />
+    <Compile Include="Dialog\IPositronDialogHandler.cs" />
     <Compile Include="IResourceRequestFilter.cs" />
     <Compile Include="PositronWindow.xaml.cs">
       <DependentUpon>PositronWindow.xaml</DependentUpon>

--- a/test/Positron.Application/App.xaml.cs
+++ b/test/Positron.Application/App.xaml.cs
@@ -7,9 +7,11 @@ using CefSharp;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Positron.Application.Handlers;
 using Positron.Server.Hosting;
 using Positron.UI;
 using Positron.UI.Builder;
+using Positron.UI.Dialog;
 
 namespace Positron.Application
 {
@@ -60,7 +62,9 @@ namespace Positron.Application
                 .UseDebugPort(8080)
                 .ConfigureServices(services =>
                 {
-                    services.AddSingleton<IGlobalScriptObject, TestScriptObject>();
+                    services
+                        .AddSingleton<IGlobalScriptObject, TestScriptObject>()
+                        .AddSingleton<IPositronDialogHandler, DialogHandler>();
                 });
 
             var windowHandler = uiBuilder.Build();

--- a/test/Positron.Application/Handlers/DialogHandler.cs
+++ b/test/Positron.Application/Handlers/DialogHandler.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using Positron.UI.Dialog;
+
+namespace Positron.Application.Handlers
+{
+    public class DialogHandler : IPositronDialogHandler
+    {
+        public bool WillHandleAlert(DialogContext context)
+        {
+            return true;
+        }
+
+        public bool WillHandleConfirmation(DialogContext context)
+        {
+            return true;
+        }
+
+        public bool WillHandlePrompt(PromptDialogContext context)
+        {
+            return false;
+        }
+
+        public Task HandleAlert(DialogContext context)
+        {
+            var operation = context.Window.Dispatcher.InvokeAsync(
+                () => MessageBox.Show(context.Window, context.MessageText, "Alert", MessageBoxButton.OK,
+                    MessageBoxImage.Information));
+
+            return operation.Task;
+        }
+
+        public async Task<bool> HandleConfirmation(DialogContext context)
+        {
+            var operation = context.Window.Dispatcher.InvokeAsync(
+                () => MessageBox.Show(context.Window, context.MessageText, "Confirmation", MessageBoxButton.YesNo,
+                    MessageBoxImage.Question));
+
+            var result = await operation.Task;
+
+            return result == MessageBoxResult.Yes;
+        }
+
+        public Task<bool> HandlePrompt(PromptDialogContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Positron.Application/Positron.Application.csproj
+++ b/test/Positron.Application/Positron.Application.csproj
@@ -57,6 +57,7 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Handlers\DialogHandler.cs" />
     <Compile Include="Models\TestModel.cs" />
     <Compile Include="Startup.cs" />
     <Compile Include="TestScriptObject.cs" />

--- a/test/Positron.Application/Scripts/main.js
+++ b/test/Positron.Application/Scripts/main.js
@@ -1,4 +1,26 @@
 ﻿$(function () {
+    $("#AlertTest").click(function (e) {
+        e.preventDefault();
+
+        window.alert("Alert Test!");
+    });
+
+    $("#ConfirmTest").click(function (e) {
+        e.preventDefault();
+
+        var result = window.confirm("Yes or no?");
+
+        window.alert(result);
+    });
+
+    $("#PromptTest").click(function (e) {
+        e.preventDefault();
+
+        var result = window.prompt("Prompt text:", "Default Value");
+
+        window.alert(result);
+    });
+
     $("#TestId").click(function (e) {
         e.preventDefault();
 

--- a/test/Positron.Application/TestScriptObject.cs
+++ b/test/Positron.Application/TestScriptObject.cs
@@ -2,7 +2,7 @@
 
 namespace Positron.Application
 {
-    class TestScriptObject : IGlobalScriptObject
+    public class TestScriptObject : IGlobalScriptObject
     {
         public string Name => "test";
 

--- a/test/Positron.Application/Views/Home/Index.cshtml
+++ b/test/Positron.Application/Views/Home/Index.cshtml
@@ -5,7 +5,9 @@
 <h2>Tests</h2>
 
 <p>
-    <a href="javascript:window.alert(test.test('test string'));">Alert Test</a><br />
+    <a href="#" id="AlertTest">Alert Test</a><br />
+    <a href="#" id="ConfirmTest">Confirm Test</a><br />
+    <a href="#" id="PromptTest">Prompt Test</a><br />
     <a href="javascript: console.log('Test Log');">Console Logging Test</a><br />
     <a href="#" id="TestAjax">Ajax Request</a><br />
     <a href="#" id="TestId">ID Route With Space Test</a><br />

--- a/test/Positron.WinFormsApplication/Program.cs
+++ b/test/Positron.WinFormsApplication/Program.cs
@@ -4,10 +4,13 @@ using System.Runtime.CompilerServices;
 using CefSharp;
 using CefSharp.Wpf;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 using Positron.Application;
+using Positron.Application.Handlers;
 using Positron.Server.Hosting;
 using Positron.UI;
 using Positron.UI.Builder;
+using Positron.UI.Dialog;
 
 namespace Positron.WinFormsApplication
 {
@@ -54,7 +57,13 @@ namespace Positron.WinFormsApplication
             app.InitializeComponent();
 
             var uiBuilder = new PositronUiBuilder()
-                .SetWebHost(webHost);
+                .SetWebHost(webHost)
+                .ConfigureServices(services =>
+                {
+                    services
+                        .AddSingleton<IGlobalScriptObject, TestScriptObject>()
+                        .AddSingleton<IPositronDialogHandler, DialogHandler>();
+                }); ;
 
             uiBuilder.UseConsoleLogger(new TestLogger());
 


### PR DESCRIPTION
Motivation
----------
Allow Positron applications to easily customize the behavior and
appearance for window.alert() and other Javascript dialogs.

Modifications
-------------
Created IPositronDialogHandler abstraction to allow consumers to inject
their own abstraction.

Created PositronJsDialogHandler to implement CefSharp's IDialogHandler,
and route requests on to the IPositronDialogHandler, if any.

Added tests to Positron.Application.

Results
-------
CefSharp's IDialogHandler has it's OnJSDialog method wrapped with an
easy to use asynchronous API.  It allows consumers to replace behavior
on window.alert(), window.confirm(), and/or window.prompt() commands.