### PR TITLE
Positron - Headers are being stripped from Http Responses (ADVANTAGE-…

### DIFF
--- a/src/Positron.UI/Internal/PositronResourceHandler.cs
+++ b/src/Positron.UI/Internal/PositronResourceHandler.cs
@@ -138,14 +138,17 @@ namespace Positron.UI.Internal
             response.StatusText = _response.ReasonPhrase;
             response.MimeType = mimeType;
 
-            response.ResponseHeaders = new NameValueCollection();
+            var headers = new NameValueCollection();
+
             foreach (var header in _response.Headers)
             {
-                response.ResponseHeaders[header.Key] = header.Value.FirstOrDefault();
+                headers[header.Key] = header.Value;
             }
 
-            if ((response.StatusCode == (int) HttpStatusCode.Redirect) ||
-                (response.StatusCode == (int) HttpStatusCode.TemporaryRedirect))
+            response.ResponseHeaders = headers;
+
+            if ((response.StatusCode == (int)HttpStatusCode.Redirect) ||
+                (response.StatusCode == (int)HttpStatusCode.TemporaryRedirect))
             {
                 var redirectLocation = _response.Headers["Location"].FirstOrDefault();
                 if (redirectLocation != null)


### PR DESCRIPTION
…8750)

Motivation
----------
Positron was stripping http response headers out of the response.

Modifications
-------------

Modified how response headers were being set.

Results
-------

Responses headers are transmitted correctly to the browser.